### PR TITLE
Add CF micrometer tags

### DIFF
--- a/common/app-starters-micrometer-common/src/main/java/org/springframework/cloud/stream/app/micrometer/common/CloudFoundryMicrometerCommonTags.java
+++ b/common/app-starters-micrometer-common/src/main/java/org/springframework/cloud/stream/app/micrometer/common/CloudFoundryMicrometerCommonTags.java
@@ -31,13 +31,13 @@ import org.springframework.context.annotation.Profile;
  * Tags are set only if the "cloud" Spring profile is set. The "cloud" profile is activated automatically when an
  * application is deployed in CF: https://docs.cloudfoundry.org/buildpacks/java/configuring-service-connections/spring-service-bindings.html#cloud-profiles
  *
- * Use the management.metrics.cloud.stream.app.cf.tags.enabled=false property to disable inserting those tags.
+ * Use the spring.cloud.stream.app.metrics.cf.tags.enabled=false property to disable inserting those tags.
  *
  * @author Christian Tzolov
  */
 @Configuration
 @Profile("cloud")
-@ConditionalOnProperty(name = "management.metrics.cloud.stream.app.cf.tags.enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(name = "spring.cloud.stream.app.metrics.cf.tags.enabled", havingValue = "true", matchIfMissing = true)
 public class CloudFoundryMicrometerCommonTags {
 
 	@Value("${vcap.application.org_name:default}")
@@ -64,12 +64,12 @@ public class CloudFoundryMicrometerCommonTags {
 	@Bean
 	public MeterRegistryCustomizer<MeterRegistry> cloudFoundryMetricsCommonTags() {
 		return registry -> registry.config()
-				.commonTags("cf_org_name", organizationName)
-				.commonTags("cf_space_id", spaceId)
-				.commonTags("cf_space_name", spaceName)
-				.commonTags("cf_app_id", applicationId)
-				.commonTags("cf_app_name", applicationName)
-				.commonTags("cf_app_version", applicationVersion)
-				.commonTags("cf_instance_index", instanceIndex);
+				.commonTags("cf.org.name", organizationName)
+				.commonTags("cf.space.id", spaceId)
+				.commonTags("cf.space.name", spaceName)
+				.commonTags("cf.app.id", applicationId)
+				.commonTags("cf.app.name", applicationName)
+				.commonTags("cf.app.version", applicationVersion)
+				.commonTags("cf.instance.index", instanceIndex);
 	}
 }

--- a/common/app-starters-micrometer-common/src/main/java/org/springframework/cloud/stream/app/micrometer/common/CloudFoundryMicrometerCommonTags.java
+++ b/common/app-starters-micrometer-common/src/main/java/org/springframework/cloud/stream/app/micrometer/common/CloudFoundryMicrometerCommonTags.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.app.micrometer.common;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * Micrometer common tags for Cloud Foundry deployment properties. Based on the CF application environment variables:
+ * https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html
+ *
+ * Tags are set only if the "cloud" Spring profile is set. The "cloud" profile is activated automatically when an
+ * application is deployed in CF: https://docs.cloudfoundry.org/buildpacks/java/configuring-service-connections/spring-service-bindings.html#cloud-profiles
+ *
+ * Use the management.metrics.cloud.stream.app.cf.tags.enabled=false property to disable inserting those tags.
+ *
+ * @author Christian Tzolov
+ */
+@Configuration
+@Profile("cloud")
+@ConditionalOnProperty(name = "management.metrics.cloud.stream.app.cf.tags.enabled", havingValue = "true", matchIfMissing = true)
+public class CloudFoundryMicrometerCommonTags {
+
+	@Value("${vcap.application.org_name:default}")
+	private String organizationName;
+
+	@Value("${vcap.application.space_id:unknown}")
+	private String spaceId;
+
+	@Value("${vcap.application.space_name:unknown}")
+	private String spaceName;
+
+	@Value("${vcap.application.application_name:unknown}")
+	private String applicationName;
+
+	@Value("${vcap.application.application_id:unknown}")
+	private String applicationId;
+
+	@Value("${vcap.application.application_version:unknown}")
+	private String applicationVersion;
+
+	@Value("${vcap.application.instance_index:0}")
+	private String instanceIndex;
+
+	@Bean
+	public MeterRegistryCustomizer<MeterRegistry> cloudFoundryMetricsCommonTags() {
+		return registry -> registry.config()
+				.commonTags("cf_org_name", organizationName)
+				.commonTags("cf_space_id", spaceId)
+				.commonTags("cf_space_name", spaceName)
+				.commonTags("cf_app_id", applicationId)
+				.commonTags("cf_app_name", applicationName)
+				.commonTags("cf_app_version", applicationVersion)
+				.commonTags("cf_instance_index", instanceIndex);
+	}
+}

--- a/common/app-starters-micrometer-common/src/main/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerCommonTags.java
+++ b/common/app-starters-micrometer-common/src/main/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerCommonTags.java
@@ -43,7 +43,7 @@ public class SpringCloudStreamMicrometerCommonTags {
 	@Value("${spring.cloud.dataflow.stream.app.label:unknown}")
 	private String applicationName;
 
-	@Value("${instance.index:0}")
+	@Value("${spring.cloud.stream.instanceIndex:0}")
 	private String instanceIndex;
 
 	@Value("${spring.cloud.application.guid:unknown}")

--- a/common/app-starters-micrometer-common/src/main/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerCommonTags.java
+++ b/common/app-starters-micrometer-common/src/main/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerCommonTags.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.config.MeterFilter;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -28,13 +29,13 @@ import org.springframework.context.annotation.Configuration;
  * instance index and guids. Later are necessary to allow discrimination and aggregation of app metrics by external
  * metrics collection and visualizaiton tools.
  *
+ * Use the management.metrics.cloud.stream.app.common.tags.enabled=false property to disable inserting those tags.
+ *
  * @author Christian Tzolov
  */
 @Configuration
+@ConditionalOnProperty(name = "management.metrics.cloud.stream.app.common.tags.enabled", havingValue = "true", matchIfMissing = true)
 public class SpringCloudStreamMicrometerCommonTags {
-
-	@Value("${spring.cloud.dataflow.cluster.name:default}")
-	private String clusterName;
 
 	@Value("${spring.cloud.dataflow.stream.name:unknown}")
 	private String streamName;
@@ -42,7 +43,7 @@ public class SpringCloudStreamMicrometerCommonTags {
 	@Value("${spring.cloud.dataflow.stream.app.label:unknown}")
 	private String applicationName;
 
-	@Value("${instance.index:unknown}")
+	@Value("${instance.index:0}")
 	private String instanceIndex;
 
 	@Value("${spring.cloud.application.guid:unknown}")
@@ -54,7 +55,6 @@ public class SpringCloudStreamMicrometerCommonTags {
 	@Bean
 	public MeterRegistryCustomizer<MeterRegistry> metricsCommonTags() {
 		return registry -> registry.config()
-				.commonTags("clusterName", clusterName)
 				.commonTags("streamName", streamName)
 				.commonTags("applicationName", applicationName)
 				.commonTags("applicationType", applicationType)

--- a/common/app-starters-micrometer-common/src/main/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerCommonTags.java
+++ b/common/app-starters-micrometer-common/src/main/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerCommonTags.java
@@ -29,12 +29,12 @@ import org.springframework.context.annotation.Configuration;
  * instance index and guids. Later are necessary to allow discrimination and aggregation of app metrics by external
  * metrics collection and visualizaiton tools.
  *
- * Use the management.metrics.cloud.stream.app.common.tags.enabled=false property to disable inserting those tags.
+ * Use the spring.cloud.stream.app.metrics.common.tags.enabled=false property to disable inserting those tags.
  *
  * @author Christian Tzolov
  */
 @Configuration
-@ConditionalOnProperty(name = "management.metrics.cloud.stream.app.common.tags.enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(name = "spring.cloud.stream.app.metrics.common.tags.enabled", havingValue = "true", matchIfMissing = true)
 public class SpringCloudStreamMicrometerCommonTags {
 
 	@Value("${spring.cloud.dataflow.stream.name:unknown}")
@@ -55,11 +55,11 @@ public class SpringCloudStreamMicrometerCommonTags {
 	@Bean
 	public MeterRegistryCustomizer<MeterRegistry> metricsCommonTags() {
 		return registry -> registry.config()
-				.commonTags("streamName", streamName)
-				.commonTags("applicationName", applicationName)
-				.commonTags("applicationType", applicationType)
-				.commonTags("instanceIndex", instanceIndex)
-				.commonTags("applicationGuid", applicationGuid);
+				.commonTags("stream.name", streamName)
+				.commonTags("application.name", applicationName)
+				.commonTags("application.type", applicationType)
+				.commonTags("instance.index", instanceIndex)
+				.commonTags("application.guid", applicationGuid);
 	}
 
 	/**

--- a/common/app-starters-micrometer-common/src/main/resources/META-INF/spring.factories
+++ b/common/app-starters-micrometer-common/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.springframework.cloud.stream.app.micrometer.common.SpringCloudStreamMicrometerCommonTags
+org.springframework.cloud.stream.app.micrometer.common.SpringCloudStreamMicrometerCommonTags,\
+org.springframework.cloud.stream.app.micrometer.common.CloudFoundryMicrometerCommonTags

--- a/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/AbstractMicrometerTagTest.java
+++ b/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/AbstractMicrometerTagTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.app.micrometer.common;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Christian Tzolov
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = AbstractMicrometerTagTest.AutoConfigurationApplication.class)
+public class AbstractMicrometerTagTest {
+
+	@Autowired
+	protected SimpleMeterRegistry simpleMeterRegistry;
+
+	protected Meter meter;
+
+	@Before
+	public void before() {
+		assertNotNull(simpleMeterRegistry);
+		meter = simpleMeterRegistry.find("jvm.memory.committed").meter();
+		assertNotNull("The jvm.memory.committed meter mast be present in SpringBoot apps!", meter);
+	}
+
+	@SpringBootApplication
+	public static class AutoConfigurationApplication {
+		public static void main(String[] args) {
+			SpringApplication.run(AutoConfigurationApplication.class, args);
+		}
+	}
+}

--- a/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/CloudFoundryMicrometerCommonTagsTest.java
+++ b/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/CloudFoundryMicrometerCommonTagsTest.java
@@ -36,13 +36,13 @@ public class CloudFoundryMicrometerCommonTagsTest {
 	public static class ActiveCloudProfileDefaultValues extends AbstractMicrometerTagTest {
 		@Test
 		public void testDefaultTagValues() {
-			assertThat(meter.getId().getTag("cf_org_name"), is("default"));
-			assertThat(meter.getId().getTag("cf_space_id"), is("unknown"));
-			assertThat(meter.getId().getTag("cf_space_name"), is("unknown"));
-			assertThat(meter.getId().getTag("cf_app_name"), is("unknown"));
-			assertThat(meter.getId().getTag("cf_app_id"), is("unknown"));
-			assertThat(meter.getId().getTag("cf_app_version"), is("unknown"));
-			assertThat(meter.getId().getTag("cf_instance_index"), is("0"));
+			assertThat(meter.getId().getTag("cf.org.name"), is("default"));
+			assertThat(meter.getId().getTag("cf.space.id"), is("unknown"));
+			assertThat(meter.getId().getTag("cf.space.name"), is("unknown"));
+			assertThat(meter.getId().getTag("cf.app.name"), is("unknown"));
+			assertThat(meter.getId().getTag("cf.app.id"), is("unknown"));
+			assertThat(meter.getId().getTag("cf.app.version"), is("unknown"));
+			assertThat(meter.getId().getTag("cf.instance.index"), is("0"));
 		}
 	}
 
@@ -59,13 +59,13 @@ public class CloudFoundryMicrometerCommonTagsTest {
 
 		@Test
 		public void testPresetTagValues() {
-			assertThat(meter.getId().getTag("cf_org_name"), is("PivotalOrg"));
-			assertThat(meter.getId().getTag("cf_space_id"), is("SpringSpaceId"));
-			assertThat(meter.getId().getTag("cf_space_name"), is("SpringSpace"));
-			assertThat(meter.getId().getTag("cf_app_name"), is("App666"));
-			assertThat(meter.getId().getTag("cf_app_id"), is("666guid"));
-			assertThat(meter.getId().getTag("cf_app_version"), is("2.0"));
-			assertThat(meter.getId().getTag("cf_instance_index"), is("123"));
+			assertThat(meter.getId().getTag("cf.org.name"), is("PivotalOrg"));
+			assertThat(meter.getId().getTag("cf.space.id"), is("SpringSpaceId"));
+			assertThat(meter.getId().getTag("cf.space.name"), is("SpringSpace"));
+			assertThat(meter.getId().getTag("cf.app.name"), is("App666"));
+			assertThat(meter.getId().getTag("cf.app.id"), is("666guid"));
+			assertThat(meter.getId().getTag("cf.app.version"), is("2.0"));
+			assertThat(meter.getId().getTag("cf.instance.index"), is("123"));
 		}
 	}
 
@@ -81,17 +81,17 @@ public class CloudFoundryMicrometerCommonTagsTest {
 
 		@Test
 		public void testDisabledTagValues() {
-			assertThat(meter.getId().getTag("cf_org_name"), is(Matchers.nullValue()));
-			assertThat(meter.getId().getTag("cf_space_id"), is(Matchers.nullValue()));
-			assertThat(meter.getId().getTag("cf_space_name"), is(Matchers.nullValue()));
-			assertThat(meter.getId().getTag("cf_app_name"), is(Matchers.nullValue()));
-			assertThat(meter.getId().getTag("cf_app_id"), is(Matchers.nullValue()));
-			assertThat(meter.getId().getTag("cf_app_version"), is(Matchers.nullValue()));
-			assertThat(meter.getId().getTag("cf_instance_index"), is(Matchers.nullValue()));
+			assertThat(meter.getId().getTag("cf.org.name"), is(Matchers.nullValue()));
+			assertThat(meter.getId().getTag("cf.space.id"), is(Matchers.nullValue()));
+			assertThat(meter.getId().getTag("cf.space.name"), is(Matchers.nullValue()));
+			assertThat(meter.getId().getTag("cf.app.name"), is(Matchers.nullValue()));
+			assertThat(meter.getId().getTag("cf.app.id"), is(Matchers.nullValue()));
+			assertThat(meter.getId().getTag("cf.app.version"), is(Matchers.nullValue()));
+			assertThat(meter.getId().getTag("cf.instance.index"), is(Matchers.nullValue()));
 		}
 	}
 
-	@TestPropertySource(properties = { "management.metrics.cloud.stream.app.cf.tags.enabled=false" })
+	@TestPropertySource(properties = { "spring.cloud.stream.app.metrics.cf.tags.enabled=false" })
 	@ActiveProfiles("cloud")
 	public static class ActiveCloudProfileDisabledProperty extends InactiveCloudProfile {
 	}

--- a/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/CloudFoundryMicrometerCommonTagsTest.java
+++ b/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/CloudFoundryMicrometerCommonTagsTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.app.micrometer.common;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Christian Tzolov
+ */
+@RunWith(Enclosed.class)
+public class CloudFoundryMicrometerCommonTagsTest {
+
+	@ActiveProfiles("cloud")
+	public static class ActiveCloudProfileDefaultValues extends AbstractMicrometerTagTest {
+		@Test
+		public void testDefaultTagValues() {
+			assertThat(meter.getId().getTag("cf_org_name"), is("default"));
+			assertThat(meter.getId().getTag("cf_space_id"), is("unknown"));
+			assertThat(meter.getId().getTag("cf_space_name"), is("unknown"));
+			assertThat(meter.getId().getTag("cf_app_name"), is("unknown"));
+			assertThat(meter.getId().getTag("cf_app_id"), is("unknown"));
+			assertThat(meter.getId().getTag("cf_app_version"), is("unknown"));
+			assertThat(meter.getId().getTag("cf_instance_index"), is("0"));
+		}
+	}
+
+	@TestPropertySource(properties = {
+			"vcap.application.org_name=PivotalOrg",
+			"vcap.application.space_id=SpringSpaceId",
+			"vcap.application.space_name=SpringSpace",
+			"vcap.application.application_name=App666",
+			"vcap.application.application_id=666guid",
+			"vcap.application.application_version=2.0",
+			"vcap.application.instance_index=123" })
+	@ActiveProfiles("cloud")
+	public static class ActiveCloudProfile extends AbstractMicrometerTagTest {
+
+		@Test
+		public void testPresetTagValues() {
+			assertThat(meter.getId().getTag("cf_org_name"), is("PivotalOrg"));
+			assertThat(meter.getId().getTag("cf_space_id"), is("SpringSpaceId"));
+			assertThat(meter.getId().getTag("cf_space_name"), is("SpringSpace"));
+			assertThat(meter.getId().getTag("cf_app_name"), is("App666"));
+			assertThat(meter.getId().getTag("cf_app_id"), is("666guid"));
+			assertThat(meter.getId().getTag("cf_app_version"), is("2.0"));
+			assertThat(meter.getId().getTag("cf_instance_index"), is("123"));
+		}
+	}
+
+	@TestPropertySource(properties = {
+			"vcap.application.org_name=PivotalOrg",
+			"vcap.application.space_id=SpringSpaceId",
+			"vcap.application.space_name=SpringSpace",
+			"vcap.application.application_name=App666",
+			"vcap.application.application_id=666guid",
+			"vcap.application.application_version=2.0",
+			"vcap.application.instance_index=123" })
+	public static class InactiveCloudProfile extends AbstractMicrometerTagTest {
+
+		@Test
+		public void testDisabledTagValues() {
+			assertThat(meter.getId().getTag("cf_org_name"), is(Matchers.nullValue()));
+			assertThat(meter.getId().getTag("cf_space_id"), is(Matchers.nullValue()));
+			assertThat(meter.getId().getTag("cf_space_name"), is(Matchers.nullValue()));
+			assertThat(meter.getId().getTag("cf_app_name"), is(Matchers.nullValue()));
+			assertThat(meter.getId().getTag("cf_app_id"), is(Matchers.nullValue()));
+			assertThat(meter.getId().getTag("cf_app_version"), is(Matchers.nullValue()));
+			assertThat(meter.getId().getTag("cf_instance_index"), is(Matchers.nullValue()));
+		}
+	}
+
+	@TestPropertySource(properties = { "management.metrics.cloud.stream.app.cf.tags.enabled=false" })
+	@ActiveProfiles("cloud")
+	public static class ActiveCloudProfileDisabledProperty extends InactiveCloudProfile {
+	}
+}
+

--- a/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerCommonTagsTest.java
+++ b/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerCommonTagsTest.java
@@ -48,7 +48,7 @@ public class SpringCloudStreamMicrometerCommonTagsTest {
 	@TestPropertySource(properties = {
 			"spring.cloud.dataflow.stream.name=myStream",
 			"spring.cloud.dataflow.stream.app.label=myApp",
-			"instance.index=666",
+			"spring.cloud.stream.instanceIndex=666",
 			"spring.cloud.application.guid=666guid",
 			"spring.cloud.dataflow.stream.app.type=source" })
 	public static class TestPresetTagValues extends AbstractMicrometerTagTest {

--- a/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerCommonTagsTest.java
+++ b/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerCommonTagsTest.java
@@ -37,11 +37,11 @@ public class SpringCloudStreamMicrometerCommonTagsTest {
 
 		@Test
 		public void testDefaultTagValues() {
-			assertThat(meter.getId().getTag("streamName"), is("unknown"));
-			assertThat(meter.getId().getTag("applicationName"), is("unknown"));
-			assertThat(meter.getId().getTag("instanceIndex"), is("0"));
-			assertThat(meter.getId().getTag("applicationType"), is("unknown"));
-			assertThat(meter.getId().getTag("applicationGuid"), is("unknown"));
+			assertThat(meter.getId().getTag("stream.name"), is("unknown"));
+			assertThat(meter.getId().getTag("application.name"), is("unknown"));
+			assertThat(meter.getId().getTag("instance.index"), is("0"));
+			assertThat(meter.getId().getTag("application.type"), is("unknown"));
+			assertThat(meter.getId().getTag("application.guid"), is("unknown"));
 		}
 	}
 
@@ -55,24 +55,24 @@ public class SpringCloudStreamMicrometerCommonTagsTest {
 
 		@Test
 		public void testPresetTagValues() {
-			assertThat(meter.getId().getTag("streamName"), is("myStream"));
-			assertThat(meter.getId().getTag("applicationName"), is("myApp"));
-			assertThat(meter.getId().getTag("instanceIndex"), is("666"));
-			assertThat(meter.getId().getTag("applicationType"), is("source"));
-			assertThat(meter.getId().getTag("applicationGuid"), is("666guid"));
+			assertThat(meter.getId().getTag("stream.name"), is("myStream"));
+			assertThat(meter.getId().getTag("application.name"), is("myApp"));
+			assertThat(meter.getId().getTag("instance.index"), is("666"));
+			assertThat(meter.getId().getTag("application.type"), is("source"));
+			assertThat(meter.getId().getTag("application.guid"), is("666guid"));
 		}
 	}
 
-	@TestPropertySource(properties = { "management.metrics.cloud.stream.app.common.tags.enabled=false" })
+	@TestPropertySource(properties = { "spring.cloud.stream.app.metrics.common.tags.enabled=false" })
 	public static class TestDisabledTagValues extends AbstractMicrometerTagTest {
 
 		@Test
 		public void testDefaultTagValues() {
-			assertThat(meter.getId().getTag("streamName"), is(nullValue()));
-			assertThat(meter.getId().getTag("applicationName"), is(nullValue()));
-			assertThat(meter.getId().getTag("instanceIndex"), is(nullValue()));
-			assertThat(meter.getId().getTag("applicationType"), is(nullValue()));
-			assertThat(meter.getId().getTag("applicationGuid"), is(nullValue()));
+			assertThat(meter.getId().getTag("stream.name"), is(nullValue()));
+			assertThat(meter.getId().getTag("application.name"), is(nullValue()));
+			assertThat(meter.getId().getTag("instance.index"), is(nullValue()));
+			assertThat(meter.getId().getTag("application.type"), is(nullValue()));
+			assertThat(meter.getId().getTag("application.guid"), is(nullValue()));
 		}
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<app-starters-docs-plugin.version>2.0.0.M1</app-starters-docs-plugin.version>
 		<app-metadata-maven-plugin-version>1.0.0.RELEASE</app-metadata-maven-plugin-version>
 		<bomsWithHigherPrecedence/>
-		<app-starters-core-dependencies.version>2.0.0.M1</app-starters-core-dependencies.version>
+		<app-starters-core-dependencies.version>2.0.0.BUILD-SNAPSHOT</app-starters-core-dependencies.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
Resolves #37
 - CF tags are activated only on 'cloud' profile
 - Allow CF tags to be disabled with management.metrics.cloud.stream.app.cf.tags.enabled=true. Enabled by default
 - SCDF common tags to be disabled with management.metrics.cloud.stream.app.common.tags.enabled=true. Enabled by default
 - Improve test coverage for all enabled/disabled use cases cases