### PR TITLE
Re-sync the micrometer tags 1.3.x with latest 2.0.0.RC1

### DIFF
--- a/common/app-starters-micrometer-common/src/main/java/org/springframework/cloud/stream/app/micrometer/common/CloudFoundryMicrometerCommonTags.java
+++ b/common/app-starters-micrometer-common/src/main/java/org/springframework/cloud/stream/app/micrometer/common/CloudFoundryMicrometerCommonTags.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.app.micrometer.common;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.spring.autoconfigure.MeterRegistryCustomizer;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * Micrometer common tags for Cloud Foundry deployment properties. Based on the CF application environment variables:
+ * https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html
+ *
+ * Tags are set only if the "cloud" Spring profile is set. The "cloud" profile is activated automatically when an
+ * application is deployed in CF: https://docs.cloudfoundry.org/buildpacks/java/configuring-service-connections/spring-service-bindings.html#cloud-profiles
+ *
+ * Use the spring.cloud.stream.app.metrics.cf.tags.enabled=false property to disable inserting those tags.
+ *
+ * @author Christian Tzolov
+ */
+@Configuration
+@Profile("cloud")
+@ConditionalOnProperty(name = "spring.cloud.stream.app.metrics.cf.tags.enabled", havingValue = "true", matchIfMissing = true)
+public class CloudFoundryMicrometerCommonTags {
+
+	@Value("${vcap.application.org_name:default}")
+	private String organizationName;
+
+	@Value("${vcap.application.space_id:unknown}")
+	private String spaceId;
+
+	@Value("${vcap.application.space_name:unknown}")
+	private String spaceName;
+
+	@Value("${vcap.application.application_name:unknown}")
+	private String applicationName;
+
+	@Value("${vcap.application.application_id:unknown}")
+	private String applicationId;
+
+	@Value("${vcap.application.application_version:unknown}")
+	private String applicationVersion;
+
+	@Value("${vcap.application.instance_index:0}")
+	private String instanceIndex;
+
+	@Bean
+	public MeterRegistryCustomizer<MeterRegistry> cloudFoundryMetricsCommonTags() {
+		return new MeterRegistryCustomizer<MeterRegistry>() {
+			@Override
+			public void customize(MeterRegistry registry) {
+				registry.config()
+						.commonTags("cf.org.name", organizationName)
+						.commonTags("cf.space.id", spaceId)
+						.commonTags("cf.space.name", spaceName)
+						.commonTags("cf.app.id", applicationId)
+						.commonTags("cf.app.name", applicationName)
+						.commonTags("cf.app.version", applicationVersion)
+						.commonTags("cf.instance.index", instanceIndex);
+			}
+		};
+	}
+}

--- a/common/app-starters-micrometer-common/src/main/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerCommonTags.java
+++ b/common/app-starters-micrometer-common/src/main/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerCommonTags.java
@@ -26,6 +26,7 @@ import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.spring.autoconfigure.MeterRegistryCustomizer;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -37,6 +38,7 @@ import org.springframework.context.annotation.Configuration;
  * @author Christian Tzolov
  */
 @Configuration
+@ConditionalOnProperty(name = "spring.cloud.stream.app.metrics.common.tags.enabled", havingValue = "true", matchIfMissing = true)
 public class SpringCloudStreamMicrometerCommonTags {
 
 	@Value("${spring.cloud.dataflow.stream.name:unknown}")
@@ -45,7 +47,7 @@ public class SpringCloudStreamMicrometerCommonTags {
 	@Value("${spring.cloud.dataflow.stream.app.label:unknown}")
 	private String applicationName;
 
-	@Value("${instance.index:unknown}")
+	@Value("${spring.cloud.stream.instanceIndex:0}")
 	private String instanceIndex;
 
 	@Value("${spring.cloud.application.guid:unknown}")
@@ -60,11 +62,11 @@ public class SpringCloudStreamMicrometerCommonTags {
 			@Override
 			public void customize(MeterRegistry registry) {
 				registry.config()
-						.commonTags("streamName", streamName)
-						.commonTags("applicationName", applicationName)
-						.commonTags("applicationType", applicationType)
-						.commonTags("instanceIndex", instanceIndex)
-						.commonTags("applicationGuid", applicationGuid);
+						.commonTags("stream.name", streamName)
+						.commonTags("application.name", applicationName)
+						.commonTags("application.type", applicationType)
+						.commonTags("instance.index", instanceIndex)
+						.commonTags("application.guid", applicationGuid);
 			}
 		};
 	}

--- a/common/app-starters-micrometer-common/src/main/resources/META-INF/spring.factories
+++ b/common/app-starters-micrometer-common/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.springframework.cloud.stream.app.micrometer.common.SpringCloudStreamMicrometerCommonTags
+org.springframework.cloud.stream.app.micrometer.common.SpringCloudStreamMicrometerCommonTags,\
+org.springframework.cloud.stream.app.micrometer.common.CloudFoundryMicrometerCommonTags

--- a/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/AbstractMicrometerTagTest.java
+++ b/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/AbstractMicrometerTagTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.app.micrometer.common;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.Map;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Christian Tzolov
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = AbstractMicrometerTagTest.AutoConfigurationApplication.class)
+public class AbstractMicrometerTagTest {
+
+	@Autowired
+	protected SimpleMeterRegistry simpleMeterRegistry;
+
+	protected Meter meter;
+
+	@Before
+	public void before() {
+		assertNotNull(simpleMeterRegistry);
+		meter = simpleMeterRegistry.find("jvm.memory.committed").meter();
+		assertNotNull("The jvm.memory.committed meter mast be present in SpringBoot apps!", meter);
+	}
+
+	@SpringBootApplication
+	public static class AutoConfigurationApplication {
+		public static void main(String[] args) {
+			SpringApplication.run(AutoConfigurationApplication.class, args);
+		}
+	}
+
+	// Hack to set the VCAP_APPLICATION for tests. Requited by
+	// https://cloud.spring.io/spring-cloud-connectors/spring-cloud-cloud-foundry-connector.html#_cloud_detection
+	static {
+		try {
+			AbstractMicrometerTagTest.setVcapApplicationEnv();
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	// Based on https://stackoverflow.com/a/7201825/4430769
+	protected static void setVcapApplicationEnv() throws Exception {
+		try {
+			Class<?> processEnvironmentClass = Class.forName("java.lang.ProcessEnvironment");
+			Field theEnvironmentField = processEnvironmentClass.getDeclaredField("theEnvironment");
+			theEnvironmentField.setAccessible(true);
+			Map<String, String> env = (Map<String, String>) theEnvironmentField.get(null);
+			env.put("VCAP_APPLICATION", "foo");
+			Field theCaseInsensitiveEnvironmentField = processEnvironmentClass.getDeclaredField("theCaseInsensitiveEnvironment");
+			theCaseInsensitiveEnvironmentField.setAccessible(true);
+			Map<String, String> cienv = (Map<String, String>) theCaseInsensitiveEnvironmentField.get(null);
+			cienv.put("VCAP_APPLICATION", "foo");
+		}
+		catch (NoSuchFieldException e) {
+			Class[] classes = Collections.class.getDeclaredClasses();
+			Map<String, String> env = System.getenv();
+			for (Class cl : classes) {
+				if ("java.util.Collections$UnmodifiableMap".equals(cl.getName())) {
+					Field field = cl.getDeclaredField("m");
+					field.setAccessible(true);
+					Object obj = field.get(env);
+					Map<String, String> map = (Map<String, String>) obj;
+					map.clear();
+					map.put("VCAP_APPLICATION", "foo");
+				}
+			}
+		}
+	}
+}

--- a/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/CloudFoundryMicrometerCommonTagsTest.java
+++ b/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/CloudFoundryMicrometerCommonTagsTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.app.micrometer.common;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Christian Tzolov
+ */
+@RunWith(Enclosed.class)
+public class CloudFoundryMicrometerCommonTagsTest {
+
+	@ActiveProfiles("cloud")
+	public static class ActiveCloudProfileDefaultValues extends AbstractMicrometerTagTest {
+
+		@Test
+		public void testDefaultTagValues() {
+			assertThat(meter.getId().getTag("cf.org.name"), is("default"));
+			assertThat(meter.getId().getTag("cf.space.id"), is("unknown"));
+			assertThat(meter.getId().getTag("cf.space.name"), is("unknown"));
+			assertThat(meter.getId().getTag("cf.app.name"), is("unknown"));
+			assertThat(meter.getId().getTag("cf.app.id"), is("unknown"));
+			assertThat(meter.getId().getTag("cf.app.version"), is("unknown"));
+			assertThat(meter.getId().getTag("cf.instance.index"), is("0"));
+		}
+	}
+
+	@TestPropertySource(properties = {
+			"vcap.application.org_name=PivotalOrg",
+			"vcap.application.space_id=SpringSpaceId",
+			"vcap.application.space_name=SpringSpace",
+			"vcap.application.application_name=App666",
+			"vcap.application.application_id=666guid",
+			"vcap.application.application_version=2.0",
+			"vcap.application.instance_index=123" })
+	@ActiveProfiles("cloud")
+	public static class ActiveCloudProfile extends AbstractMicrometerTagTest {
+
+		@Test
+		public void testPresetTagValues() {
+			assertThat(meter.getId().getTag("cf.org.name"), is("PivotalOrg"));
+			assertThat(meter.getId().getTag("cf.space.id"), is("SpringSpaceId"));
+			assertThat(meter.getId().getTag("cf.space.name"), is("SpringSpace"));
+			assertThat(meter.getId().getTag("cf.app.name"), is("App666"));
+			assertThat(meter.getId().getTag("cf.app.id"), is("666guid"));
+			assertThat(meter.getId().getTag("cf.app.version"), is("2.0"));
+			assertThat(meter.getId().getTag("cf.instance.index"), is("123"));
+		}
+	}
+
+	@TestPropertySource(properties = {
+			"vcap.application.org_name=PivotalOrg",
+			"vcap.application.space_id=SpringSpaceId",
+			"vcap.application.space_name=SpringSpace",
+			"vcap.application.application_name=App666",
+			"vcap.application.application_id=666guid",
+			"vcap.application.application_version=2.0",
+			"vcap.application.instance_index=123" })
+	public static class InactiveCloudProfile extends AbstractMicrometerTagTest {
+
+		@Test
+		public void testDisabledTagValues() {
+			assertThat(meter.getId().getTag("cf.org.name"), is(Matchers.nullValue()));
+			assertThat(meter.getId().getTag("cf.space.id"), is(Matchers.nullValue()));
+			assertThat(meter.getId().getTag("cf.space.name"), is(Matchers.nullValue()));
+			assertThat(meter.getId().getTag("cf.app.name"), is(Matchers.nullValue()));
+			assertThat(meter.getId().getTag("cf.app.id"), is(Matchers.nullValue()));
+			assertThat(meter.getId().getTag("cf.app.version"), is(Matchers.nullValue()));
+			assertThat(meter.getId().getTag("cf.instance.index"), is(Matchers.nullValue()));
+		}
+	}
+
+	@TestPropertySource(properties = { "spring.cloud.stream.app.metrics.cf.tags.enabled=false" })
+	@ActiveProfiles("cloud")
+	public static class ActiveCloudProfileDisabledProperty extends InactiveCloudProfile {
+	}
+}


### PR DESCRIPTION
Resolves #41
 - Adjust tag names to use dot-based notation
 - Add CF tags on cloud profile
 - Add tag generation enable/disable properties
 - Additional efforts (compared to 2.0.0.RC1) to set the VCAP_APPLICATION for testing the CF tags.