### PR TITLE
Add explicit Order for common security config

### DIFF
--- a/common/app-starters-security-common/src/main/java/org/springframework/cloud/stream/app/security/common/SecurityCommonAutoConfiguration.java
+++ b/common/app-starters-security-common/src/main/java/org/springframework/cloud/stream/app/security/common/SecurityCommonAutoConfiguration.java
@@ -51,7 +51,7 @@ public class SecurityCommonAutoConfiguration {
 	 */
 	@Configuration
 	@ConditionalOnProperty(name = "spring.cloud.stream.security.enabled", havingValue = "false", matchIfMissing = true)
-	@Order(Ordered.LOWEST_PRECEDENCE)
+	@Order(Ordered.LOWEST_PRECEDENCE-150)
 	protected static class DisableSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
 		@Override

--- a/common/app-starters-security-common/src/main/java/org/springframework/cloud/stream/app/security/common/SecurityCommonAutoConfiguration.java
+++ b/common/app-starters-security-common/src/main/java/org/springframework/cloud/stream/app/security/common/SecurityCommonAutoConfiguration.java
@@ -21,6 +21,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -49,6 +51,7 @@ public class SecurityCommonAutoConfiguration {
 	 */
 	@Configuration
 	@ConditionalOnProperty(name = "spring.cloud.stream.security.enabled", havingValue = "false", matchIfMissing = true)
+	@Order(Ordered.LOWEST_PRECEDENCE)
 	protected static class DisableSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
 		@Override


### PR DESCRIPTION
 - DisableSecurityConfiguration to have the lowest precedence

Resolves #57