### PR TITLE
add default micrometer autoconfigurations

### DIFF
--- a/common/app-starters-micrometer-common/src/main/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerEnvironmentPostProcessor.java
+++ b/common/app-starters-micrometer-common/src/main/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerEnvironmentPostProcessor.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.app.micrometer.common;
+
+import java.util.Properties;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.PropertiesPropertySource;
+
+/**
+ * Disables all Micrometer Repositories added as App Starters dependencies by default.
+ * That means disabling Datadog, Influx and Prometheus.
+ *
+ * @author Christian Tzolov
+ */
+public class SpringCloudStreamMicrometerEnvironmentPostProcessor implements EnvironmentPostProcessor {
+
+	protected static final String PROPERTY_SOURCE_KEY_NAME = SpringCloudStreamMicrometerEnvironmentPostProcessor.class.getName();
+
+	private final static String METRICS_PROPERTY_NAME_TEMPLATE = "management.metrics.export.%s.enabled";
+
+	private final static String[] METRICS_REPOSITORY_NAMES = new String[] { "datadog", "influx", "prometheus" };
+
+	@Override
+	public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+		Properties properties = new Properties();
+
+		if (!environment.containsProperty("management.endpoints.web.exposure.include")) {
+			properties.setProperty("management.endpoints.web.exposure.include", "prometheus");
+		}
+
+		for (String metricsRepositoryName : METRICS_REPOSITORY_NAMES) {
+			String propertyKey = String.format(METRICS_PROPERTY_NAME_TEMPLATE, metricsRepositoryName);
+
+			// Back off if the property is already set.
+			if (!environment.containsProperty(propertyKey)) {
+				properties.setProperty(propertyKey, "false");
+			}
+		}
+
+		// This post-processor is called multiple times but sets the properties only once.
+		if (!properties.isEmpty()) {
+			PropertiesPropertySource propertiesPropertySource =
+					new PropertiesPropertySource(PROPERTY_SOURCE_KEY_NAME, properties);
+			environment.getPropertySources().addLast(propertiesPropertySource);
+		}
+	}
+}

--- a/common/app-starters-micrometer-common/src/main/resources/META-INF/spring.factories
+++ b/common/app-starters-micrometer-common/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,6 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.springframework.cloud.stream.app.micrometer.common.SpringCloudStreamMicrometerCommonTags,\
 org.springframework.cloud.stream.app.micrometer.common.CloudFoundryMicrometerCommonTags
+org.springframework.boot.env.EnvironmentPostProcessor=\
+org.springframework.cloud.stream.app.micrometer.common.SpringCloudStreamMicrometerEnvironmentPostProcessor
+

--- a/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/AbstractMicrometerTagTest.java
+++ b/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/AbstractMicrometerTagTest.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.junit.Assert.assertNotNull;
@@ -37,6 +38,9 @@ public class AbstractMicrometerTagTest {
 
 	@Autowired
 	protected SimpleMeterRegistry simpleMeterRegistry;
+
+	@Autowired
+	protected ConfigurableApplicationContext context;
 
 	protected Meter meter;
 

--- a/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerEnvironmentPostProcessorTest.java
+++ b/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerEnvironmentPostProcessorTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.app.micrometer.common;
+
+import org.hamcrest.core.Is;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import org.springframework.core.env.PropertySource;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Christian Tzolov
+ */
+@RunWith(Enclosed.class)
+public class SpringCloudStreamMicrometerEnvironmentPostProcessorTest {
+
+	public static class TestDefaultMetricsEnabledProperties extends AbstractMicrometerTagTest {
+
+		@Test
+		public void testDefaultProperties() {
+			assertNotNull(context);
+
+			PropertySource propertySource = context.getEnvironment().getPropertySources()
+					.get(SpringCloudStreamMicrometerEnvironmentPostProcessor.PROPERTY_SOURCE_KEY_NAME);
+
+			assertNotNull("Property source "
+							+ SpringCloudStreamMicrometerEnvironmentPostProcessor.PROPERTY_SOURCE_KEY_NAME + " is null",
+					propertySource);
+
+			assertThat(propertySource.getProperty("management.metrics.export.influx.enabled"), Is.is("false"));
+			assertThat(propertySource.getProperty("management.metrics.export.prometheus.enabled"), Is.is("false"));
+			assertThat(propertySource.getProperty("management.metrics.export.datadog.enabled"), Is.is("false"));
+
+			assertThat(propertySource.getProperty("management.endpoints.web.exposure.include"), Is.is("prometheus"));
+
+			assertThat(context.getEnvironment().getProperty("management.metrics.export.influx.enabled"), Is.is("false"));
+			assertThat(context.getEnvironment().getProperty("management.metrics.export.prometheus.enabled"), Is.is("false"));
+			assertThat(context.getEnvironment().getProperty("management.metrics.export.datadog.enabled"), Is.is("false"));
+
+			assertThat(context.getEnvironment().getProperty("management.endpoints.web.exposure.include"), Is.is("prometheus"));
+
+		}
+	}
+
+	@TestPropertySource(properties = {
+			"management.metrics.export.influx.enabled=true",
+			"management.metrics.export.prometheus.enabled=true",
+			"management.metrics.export.datadog.enabled=true",
+			"management.endpoints.web.exposure.include=info,health"})
+	public static class TestOverrideMetricsEnabledProperties extends AbstractMicrometerTagTest {
+
+		@Test
+		public void testOverrideProperties() {
+			assertNotNull(context);
+
+			PropertySource propertySource = context.getEnvironment().getPropertySources()
+					.get(SpringCloudStreamMicrometerEnvironmentPostProcessor.PROPERTY_SOURCE_KEY_NAME);
+
+			assertNull("Property source "
+							+ SpringCloudStreamMicrometerEnvironmentPostProcessor.PROPERTY_SOURCE_KEY_NAME + " is not null",
+					propertySource);
+
+			assertThat(context.getEnvironment().getProperty("management.metrics.export.influx.enabled"), Is.is("true"));
+			assertThat(context.getEnvironment().getProperty("management.metrics.export.prometheus.enabled"), Is.is("true"));
+			assertThat(context.getEnvironment().getProperty("management.metrics.export.datadog.enabled"), Is.is("true"));
+
+			assertThat(context.getEnvironment().getProperty("management.endpoints.web.exposure.include"), Is.is("info,health"));
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,18 @@
 										<artifactId>app-starters-micrometer-common</artifactId>
 									</dependency>
 									<dependency>
+										<groupId>io.micrometer</groupId>
+										<artifactId>micrometer-registry-influx</artifactId>
+									</dependency>
+									<dependency>
+										<groupId>io.micrometer</groupId>
+										<artifactId>micrometer-registry-prometheus</artifactId>
+									</dependency>
+									<dependency>
+										<groupId>io.micrometer</groupId>
+										<artifactId>micrometer-registry-datadog</artifactId>
+									</dependency>
+									<dependency>
 										<groupId>org.springframework.cloud</groupId>
 										<artifactId>spring-cloud-cloudfoundry-connector</artifactId>
 									</dependency>


### PR DESCRIPTION
 - Add additionalGlobalDependencies to spring-cloud-stream-app-maven-plugin for the influx, prometheus and datadog registries
 - Add SpringCloudStreamMicrometerEnvironmentPostProcessor to disable the Influx, Prometheus and Datadog micrometer registries by default
 - Upgrade SCSt version to 2.1.0.RC2 and SCSt-dependencies to Fishtown.RC2
 - Expose prometheus actuator endpoint

Resolves #62