### PR TITLE
Override time tag values for InfluxDB meters

### DIFF
--- a/common/app-starters-micrometer-common/pom.xml
+++ b/common/app-starters-micrometer-common/pom.xml
@@ -9,5 +9,12 @@
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>app-starters-micrometer-common</artifactId>
+	<dependencies>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-influx</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/common/app-starters-micrometer-common/src/main/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerCommonTags.java
+++ b/common/app-starters-micrometer-common/src/main/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerCommonTags.java
@@ -62,14 +62,15 @@ public class SpringCloudStreamMicrometerCommonTags {
 				.commonTags("application.guid", applicationGuid);
 	}
 
-	/**
-	 * This is a work around for: https://github.com/micrometer-metrics/micrometer/issues/544
-	 */
 	@Bean
 	public MeterRegistryCustomizer<MeterRegistry> renameNameTag() {
 		return registry -> {
 			if (registry.getClass().getCanonicalName().contains("AtlasMeterRegistry")) {
 				registry.config().meterFilter(MeterFilter.renameTag("spring.integration", "name", "aname"));
+			}
+			if (registry.getClass().getCanonicalName().contains("InfluxMeterRegistry")) {
+				registry.config().meterFilter(MeterFilter.replaceTagValues("application.name",
+						tagValue -> ("time".equalsIgnoreCase(tagValue)) ? "atime" : tagValue));
 			}
 		};
 	}

--- a/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/AbstractMicrometerTagTest.java
+++ b/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/AbstractMicrometerTagTest.java
@@ -15,16 +15,23 @@
  */
 package org.springframework.cloud.stream.app.micrometer.common;
 
+import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleProperties;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimplePropertiesConfigAdapter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.junit.Assert.assertNotNull;
@@ -52,9 +59,24 @@ public class AbstractMicrometerTagTest {
 	}
 
 	@SpringBootApplication
+	@EnableConfigurationProperties(SimpleProperties.class)
 	public static class AutoConfigurationApplication {
+
 		public static void main(String[] args) {
 			SpringApplication.run(AutoConfigurationApplication.class, args);
 		}
+
+		@Bean
+		public SimpleMeterRegistry simpleMeterRegistry(SimpleConfig config, Clock clock) {
+			return new SimpleMeterRegistry(config, clock);
+		}
+
+		@Bean
+		@ConditionalOnMissingBean
+		public SimpleConfig simpleConfig(SimpleProperties simpleProperties) {
+			return new SimplePropertiesConfigAdapter(simpleProperties);
+		}
+
+
 	}
 }

--- a/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/InfluxReservedKeywordHandlingTest.java
+++ b/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/InfluxReservedKeywordHandlingTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.app.micrometer.common;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.influx.InfluxMeterRegistry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Christian Tzolov
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = InfluxReservedKeywordHandlingTest.AutoConfigurationApplication.class,
+		properties = {
+				"management.metrics.export.influx.enabled=true",
+				"spring.cloud.dataflow.stream.app.label=time" })
+public class InfluxReservedKeywordHandlingTest {
+
+	@Autowired
+	protected InfluxMeterRegistry influxMeterRegistry;
+
+	@Test
+	public void testPresetTagValues() {
+		assertNotNull(influxMeterRegistry);
+		Meter meter = influxMeterRegistry.find("jvm.memory.committed").meter();
+		assertNotNull("The jvm.memory.committed meter mast be present in SpringBoot apps!", meter);
+
+		assertThat(meter.getId().getTag("application.name"), is("atime"));
+	}
+
+	@SpringBootApplication
+	public static class AutoConfigurationApplication {
+		public static void main(String[] args) {
+			SpringApplication.run(AutoConfigurationApplication.class, args);
+		}
+	}
+}

--- a/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerEnvironmentPostProcessorTest.java
+++ b/common/app-starters-micrometer-common/src/test/java/org/springframework/cloud/stream/app/micrometer/common/SpringCloudStreamMicrometerEnvironmentPostProcessorTest.java
@@ -62,6 +62,7 @@ public class SpringCloudStreamMicrometerEnvironmentPostProcessorTest {
 	}
 
 	@TestPropertySource(properties = {
+			"management.metrics.export.simple.enabled=true",
 			"management.metrics.export.influx.enabled=true",
 			"management.metrics.export.prometheus.enabled=true",
 			"management.metrics.export.datadog.enabled=true",


### PR DESCRIPTION
 - Add MeterFilter to override the 'time' values of 'application.name' tags into 'atime'
 - Add tests

 Resolves #67