### PR TITLE
Reintroducing Spring Cloud Services Config Client in apps.

### DIFF
--- a/common/app-starters-micrometer-common/pom.xml
+++ b/common/app-starters-micrometer-common/pom.xml
@@ -9,11 +9,16 @@
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>app-starters-micrometer-common</artifactId>
+
 	<dependencies>
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-influx</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.pivotal.cfenv</groupId>
+			<artifactId>java-cfenv-test-support</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/common/app-starters-micrometer-common/src/test/resources/org/springframework/cloud/stream/app/micrometer/common/cloud-test-info.json
+++ b/common/app-starters-micrometer-common/src/test/resources/org/springframework/cloud/stream/app/micrometer/common/cloud-test-info.json
@@ -1,0 +1,12 @@
+{
+  "name": "sso",
+  "label": "sso",
+  "plan": "notfree",
+  "tags": ["configuration"],
+  "credentials":{
+    "uri": "http://pivotal.io",
+    "client_id": "fakeClientId",
+    "client_secret": "fakeSecret",
+    "access_token_uri": "token"
+  }
+}

--- a/core-dependencies/pom.xml
+++ b/core-dependencies/pom.xml
@@ -20,6 +20,8 @@
         <spring-cloud-stream.version>2.1.1.RELEASE</spring-cloud-stream.version>
 		<spring-cloud-dependencies.version>Greenwich.RELEASE</spring-cloud-dependencies.version>
 		<spring-cloud-stream-dependencies.version>Fishtown.SR1</spring-cloud-stream-dependencies.version>
+		<spring-cloud-services-config-client.version>2.1.1.RELEASE</spring-cloud-services-config-client.version>
+		<java-cfenv-boot.version>1.0.1.RELEASE</java-cfenv-boot.version>
 	</properties>
 
 	<dependencyManagement>
@@ -111,6 +113,17 @@
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-stream-test-support-internal</artifactId>
 				<version>${spring-cloud-stream.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.pivotal.spring.cloud</groupId>
+				<artifactId>spring-cloud-services-starter-config-client</artifactId>
+				<version>${spring-cloud-services-config-client.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.pivotal.cfenv</groupId>
+				<artifactId>java-cfenv-test-support</artifactId>
+				<version>${java-cfenv-boot.version}</version>
+				<scope>test</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -100,10 +100,10 @@
 			<artifactId>spring-cloud-stream-test-support</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<!--<dependency>-->
-			<!--<groupId>io.pivotal.spring.cloud</groupId>-->
-			<!--<artifactId>spring-cloud-services-starter-config-client</artifactId>-->
-		<!--</dependency>-->
+		<dependency>
+			<groupId>io.pivotal.spring.cloud</groupId>
+			<artifactId>spring-cloud-services-starter-config-client</artifactId>
+		</dependency>
 	</dependencies>
 
     <build>


### PR DESCRIPTION
 - Enabled spring-cloud-services-starter-config-client in app starters core
 - Fixed tests in CloudFoundryMicrometerCommonTagsTest by mocking the vcap configuration
 - Reused some utility classes/code from the java-cfenv project

Fixes #71