### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/common/app-starters-metadata-store-common/README.adoc
+++ b/common/app-starters-metadata-store-common/README.adoc
@@ -59,7 +59,7 @@ The `GemfireMetadataStore` requires these dependencies for auto-configuration:
 </dependency>
 ----
 
-or when your environment is based on the Open Source http://geode.apache.org/[Apache Geode]:
+or when your environment is based on the Open Source https://geode.apache.org/[Apache Geode]:
 
 [source,xml]
 ----
@@ -127,7 +127,7 @@ Also a `CuratorFramework` bean can be provided to override a default auto-config
 
 ==== AWS DymanoDb
 
-The `DynamoDbMetadataStore` requires regular Spring Cloud AWS auto-configuration for http://cloud.spring.io/spring-cloud-static/spring-cloud-aws/2.0.0.RELEASE/single/spring-cloud-aws.html#_spring_boot_auto_configuration[Spring Boot] and minimal set of dependencies is like this:
+The `DynamoDbMetadataStore` requires regular Spring Cloud AWS auto-configuration for https://cloud.spring.io/spring-cloud-static/spring-cloud-aws/2.0.0.RELEASE/single/spring-cloud-aws.html#_spring_boot_auto_configuration[Spring Boot] and minimal set of dependencies is like this:
 
 [source,xml]
 ----

--- a/common/app-starters-micrometer-common/src/test/resources/org/springframework/cloud/stream/app/micrometer/common/pcf-scs-info.json
+++ b/common/app-starters-micrometer-common/src/test/resources/org/springframework/cloud/stream/app/micrometer/common/pcf-scs-info.json
@@ -5,7 +5,7 @@
     "plan": "notfree",
     "tags": ["configuration"],
     "credentials":{
-      "uri": "http://pivotal.io",
+      "uri": "https://pivotal.io",
       "client_id": "fakeClientId",
       "client_secret": "fakeSecret",
       "access_token_uri": "token"


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-static/spring-cloud-aws/2.0.0.RELEASE/single/spring-cloud-aws.html with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-static/spring-cloud-aws/2.0.0.RELEASE/single/spring-cloud-aws.html ([https](https://cloud.spring.io/spring-cloud-static/spring-cloud-aws/2.0.0.RELEASE/single/spring-cloud-aws.html) result 200).
* [ ] http://geode.apache.org/ with 1 occurrences migrated to:  
  https://geode.apache.org/ ([https](https://geode.apache.org/) result 200).
* [ ] http://pivotal.io with 1 occurrences migrated to:  
  https://pivotal.io ([https](https://pivotal.io) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).